### PR TITLE
fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ than 200ms and safe primes about 10 seconds on modern hardware.
 # Installation
 Add the following to your `Cargo.toml` file:
 ```toml
-glass-pumpkin = "0.4"
+glass_pumpkin = "0.4"
 ```
 
 # Example


### PR DESCRIPTION
```
    Updating crates.io index
error: no matching package named `glass-pumpkin` found
location searched: registry `https://github.com/rust-lang/crates.io-index`
perhaps you meant: glass_pumpkin
```

Thanks by the way for making this! I'm using it and just thought this would be easy to fix for future users that might cp and paste from the `crates.io` page or this repo's readme. They'd figure it out from the error message anyway so it's not necessary, just clearer