### PR TITLE
Upgrades dependencies to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/mikelodder7/glass_pumpkin"
 documentation = "https://docs.rs/glass_pumpkin"
 homepage = "https://crates.io/crates/glass_pumpkin"
 readme = "README.md"
+edition = "2018"
 
 [badges]
 maintenance = { status = "passively-maintained" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,14 @@ readme = "README.md"
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-num-bigint = { version = "0.3", features = ["rand"] }
-num-traits = "0.2"
-num-integer = "0.1"
-rand = "0.7"
-lazy_static = "1.2"
+num-bigint = { version = "0.4.0", features = ["rand"] }
+num-traits = "0.2.14"
+num-integer = "0.1.44"
+rand = "0.8.3"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
-criterion = "0.2"
+criterion = { version = "0.3.4", features = ["html_reports"] }
 
 [[bench]]
 name = "gen_safe_prime"

--- a/README.md
+++ b/README.md
@@ -26,13 +26,11 @@ glass_pumpkin = "0.4"
 
 # Example
 ```rust
-extern crate glass_pumpkin;
-
 use glass_pumpkin::prime;
 
 fn main() {
-    let p = prime::new(1024);
-    let q = prime::new(1024);
+    let p = prime::new(1024).unwrap();
+    let q = prime::new(1024).unwrap();
 
     let n = p * q;
 
@@ -42,17 +40,13 @@ fn main() {
 
 You can also supply `OsRng` and generate primes from that.
 ```rust
-extern crate glass_pumpkin;
-extern crate rand;
-
 use glass_pumpkin::prime;
-
-use rand::prelude::*;
+use rand::rngs::OsRng;
 
 fn main() {
-    let mut rng = OsRng::new().unwrap();
-    let p = prime::from_rng(1024, &mut rng);
-    let q = prime::from_rng(1024, &mut rng);
+    let mut rng = OsRng;
+    let p = prime::from_rng(1024, &mut rng).unwrap();
+    let q = prime::from_rng(1024, &mut rng).unwrap();
 
     let n = p * q;
     println!("{}", n);
@@ -77,20 +71,17 @@ Safe primes require (n-1)/2 also be prime.
 
 You can use this crate to check numbers for primality.
 ```rust
-extern crate glass_pumpkin;
-extern crate num_bigint;
-
 use glass_pumpkin::prime;
 use glass_pumpkin::safe_prime;
 use num_bigint::BigUint;
 
 fn main() {
 
-    if prime::check(&BigUint::from(5)) {
+    if prime::check(&BigUint::new([5].to_vec())) {
         println!("is prime");
     }
 
-    if safe_prime::check(&BigUint::from(7)) {
+    if safe_prime::check(&BigUint::new([7].to_vec())) {
         println!("is safe prime");
     }
 }

--- a/benches/gen_safe_prime.rs
+++ b/benches/gen_safe_prime.rs
@@ -1,8 +1,4 @@
-#[macro_use]
-extern crate criterion;
-extern crate glass_pumpkin;
-
-use criterion::Criterion;
+use criterion::{criterion_group, criterion_main, Criterion};
 use glass_pumpkin::safe_prime::new;
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/src/common.rs
+++ b/src/common.rs
@@ -3,10 +3,10 @@ use num_integer::Integer;
 use num_traits::identities::{One, Zero};
 use num_traits::Signed;
 
+use crate::error::{Error, Result};
+use lazy_static::lazy_static;
 use rand::thread_rng;
 use rand::Rng;
-use lazy_static::lazy_static;
-use crate::error::{Error, Result};
 
 pub const MIN_BIT_LENGTH: usize = 128;
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -5,7 +5,7 @@ use num_traits::Signed;
 
 use rand::thread_rng;
 use rand::Rng;
-
+use lazy_static::lazy_static;
 use crate::error::{Error, Result};
 
 pub const MIN_BIT_LENGTH: usize = 128;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,13 +16,6 @@
 //! 3. Test the candidate with Fermat's Theorem.
 //! 4. Runs Baillie-PSW test with log2(bits) + 5 Miller-Rabin tests
 
-#[macro_use]
-extern crate lazy_static;
-pub extern crate num_bigint;
-extern crate num_integer;
-extern crate num_traits;
-extern crate rand;
-
 mod common;
 pub mod error;
 pub mod prime;


### PR DESCRIPTION
The current version does not support the latest versions of the libraries `num-bigint` and `rand`, forcing you to use older versions. With these changes you bring all dependencies to their respective latest versions. Also using the 2018 edition allows you to remove the `extern crate` syntax, and improves compatibility with future versions of Rust. Given the changes I updated also the examples of the README.md to stay consistent with library changes.