### PR TITLE
Improve formatting of crate-level docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,13 @@
 )]
 //! A crate for generating large prime numbers, suitable for cryptography.
 //!
-//! `Primes` are generated similarly to OpenSSL except it applies some recommendations from the (Prime and Prejudice)[https://eprint.iacr.org/2018/749.pdf]
+//! Primes are generated similarly to OpenSSL except it applies some recommendations
+//! from the [Prime and Prejudice](https://eprint.iacr.org/2018/749.pdf).
 //!
 //! 1. Generate a random odd number of a given bit-length.
 //! 2. Divide the candidate by the first 2048 prime numbers
 //! 3. Test the candidate with Fermat's Theorem.
-//! 4. Runs Baillie-PSW test with log2(bits) + 5 Miller-Rabin tests
+//! 4. Runs Baillie-PSW test with `log2(bits) + 5` Miller-Rabin tests
 
 mod common;
 pub mod error;


### PR DESCRIPTION
* "Primes" is no longer in a code block
* Rewrap line of >100 characters
* Fix link syntax
* Make last line more readable by using code block