### PR TITLE
Remove use of thread_rng in common

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,12 @@ core2 = "0.4"
 num-bigint = { version = "0.4", features = ["rand"] }
 num-traits = "0.2"
 num-integer = "0.1"
-rand = { version = "0.8", default-features = false }
+rand_core = { version = "0.6", features = ["getrandom"] }
 lazy_static = "1.4"
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }
-rand = { version = "0.8", default-features = true }
+rand = "0.8"
 
 [[bench]]
 name = "gen_safe_prime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,12 @@ core2 = "0.4"
 num-bigint = { version = "0.4", features = ["rand"] }
 num-traits = "0.2"
 num-integer = "0.1"
-rand = "0.8"
+rand = { version = "0.8", default-features = false }
 lazy_static = "1.4"
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }
+rand = { version = "0.8", default-features = true }
 
 [[bench]]
 name = "gen_safe_prime"

--- a/src/common.rs
+++ b/src/common.rs
@@ -6,13 +6,13 @@ use num_traits::Signed;
 use crate::error::{Error, Result};
 use crate::rand::Randoms;
 use lazy_static::lazy_static;
-use rand::Rng;
+use rand_core::RngCore;
 
 pub const MIN_BIT_LENGTH: usize = 128;
 
 /// Create a new prime number with size `bit_length` sourced
-/// from an already-initialized `Rng`
-pub fn gen_prime<R: Rng + ?Sized>(bit_length: usize, rng: &mut R) -> Result {
+/// from an already-initialized `RngCore`
+pub fn gen_prime<R: RngCore + ?Sized>(bit_length: usize, rng: &mut R) -> Result {
     if bit_length < MIN_BIT_LENGTH {
         Err(Error::BitLength(bit_length))
     } else {
@@ -38,8 +38,8 @@ pub fn gen_prime<R: Rng + ?Sized>(bit_length: usize, rng: &mut R) -> Result {
 }
 
 /// Constructs a new `SafePrime` with the size of `bit_length` bits, sourced
-/// from an already-initialized `Rng`.
-pub fn gen_safe_prime<R: Rng + ?Sized>(bit_length: usize, rng: &mut R) -> Result {
+/// from an already-initialized `RngCore`.
+pub fn gen_safe_prime<R: RngCore + ?Sized>(bit_length: usize, rng: &mut R) -> Result {
     let two = (*TWO).clone();
     let three = (*THREE).clone();
     if bit_length < MIN_BIT_LENGTH {
@@ -61,7 +61,7 @@ pub fn gen_safe_prime<R: Rng + ?Sized>(bit_length: usize, rng: &mut R) -> Result
 }
 
 /// Checks if number is a prime using the Baillie-PSW test
-pub fn is_prime_baillie_psw<R: Rng + ?Sized>(candidate: &BigUint, rng: &mut R) -> bool {
+pub fn is_prime_baillie_psw<R: RngCore + ?Sized>(candidate: &BigUint, rng: &mut R) -> bool {
     _is_prime(
         candidate,
         required_checks(candidate.bits() as usize),
@@ -71,7 +71,7 @@ pub fn is_prime_baillie_psw<R: Rng + ?Sized>(candidate: &BigUint, rng: &mut R) -
 }
 
 /// Checks if number is a safe prime using the Baillie-PSW test
-pub fn is_safe_prime_baillie_psw<R: Rng + ?Sized>(candidate: &BigUint, rng: &mut R) -> bool {
+pub fn is_safe_prime_baillie_psw<R: RngCore + ?Sized>(candidate: &BigUint, rng: &mut R) -> bool {
     _is_safe_prime(
         candidate,
         required_checks(candidate.bits() as usize),
@@ -81,7 +81,7 @@ pub fn is_safe_prime_baillie_psw<R: Rng + ?Sized>(candidate: &BigUint, rng: &mut
 }
 
 /// Checks if number is a safe prime
-pub fn is_safe_prime<R: Rng + ?Sized>(candidate: &BigUint, rng: &mut R) -> bool {
+pub fn is_safe_prime<R: RngCore + ?Sized>(candidate: &BigUint, rng: &mut R) -> bool {
     _is_safe_prime(
         candidate,
         required_checks(candidate.bits() as usize),
@@ -91,7 +91,7 @@ pub fn is_safe_prime<R: Rng + ?Sized>(candidate: &BigUint, rng: &mut R) -> bool 
 }
 
 /// Common function for `is_safe_prime`
-fn _is_safe_prime<R: Rng + ?Sized>(
+fn _is_safe_prime<R: RngCore + ?Sized>(
     candidate: &BigUint,
     checks: usize,
     force2: bool,
@@ -116,7 +116,7 @@ fn _is_safe_prime<R: Rng + ?Sized>(
 /// 2- Perform a Fermat Test
 /// 3- Perform log2(bitlength) + 5 rounds of Miller-Rabin
 ///    depending on the number of bits
-pub fn is_prime<R: Rng + ?Sized>(candidate: &BigUint, rng: &mut R) -> bool {
+pub fn is_prime<R: RngCore + ?Sized>(candidate: &BigUint, rng: &mut R) -> bool {
     _is_prime(
         candidate,
         required_checks(candidate.bits() as usize),
@@ -126,7 +126,7 @@ pub fn is_prime<R: Rng + ?Sized>(candidate: &BigUint, rng: &mut R) -> bool {
 }
 
 /// Common function for `is_prime`
-fn _is_prime<R: Rng + ?Sized>(
+fn _is_prime<R: RngCore + ?Sized>(
     candidate: &BigUint,
     checks: usize,
     force2: bool,
@@ -166,7 +166,7 @@ fn required_checks(bits: usize) -> usize {
 
 /// Perform Fermat's little theorem on the candidate to determine probable
 /// primality.
-fn fermat<R: Rng + ?Sized>(candidate: &BigUint, rng: &mut R) -> bool {
+fn fermat<R: RngCore + ?Sized>(candidate: &BigUint, rng: &mut R) -> bool {
     let random = rng.gen_biguint_range(&BigUint::one(), candidate);
 
     let result = random.modpow(&(candidate - 1_u8), candidate);
@@ -175,7 +175,7 @@ fn fermat<R: Rng + ?Sized>(candidate: &BigUint, rng: &mut R) -> bool {
 }
 
 /// Perform miller rabin primality tests
-fn miller_rabin<R: Rng + ?Sized>(
+fn miller_rabin<R: RngCore + ?Sized>(
     candidate: &BigUint,
     limit: usize,
     force2: bool,

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,6 @@
 use crate::common::MIN_BIT_LENGTH;
 use core::{fmt, result};
 use core2::error;
-use rand;
 
 /// Default result struct
 pub type Result = result::Result<num_bigint::BigUint, Error>;
@@ -12,7 +11,7 @@ pub type Result = result::Result<num_bigint::BigUint, Error>;
 #[derive(Debug)]
 pub enum Error {
     /// Handles when the OS Rng fails to initialize
-    OsRngInitialization(rand::Error),
+    OsRngInitialization(rand_core::Error),
     /// Handles when the bit sizes are too small
     BitLength(usize),
 }
@@ -34,8 +33,8 @@ impl fmt::Display for Error {
 
 impl error::Error for Error {}
 
-impl From<rand::Error> for Error {
-    fn from(err: rand::Error) -> Error {
+impl From<rand_core::Error> for Error {
+    fn from(err: rand_core::Error) -> Error {
         Error::OsRngInitialization(err)
     }
 }

--- a/src/prime.rs
+++ b/src/prime.rs
@@ -1,6 +1,6 @@
 //! Generates cryptographically secure prime numbers.
 
-use rand::rngs::OsRng;
+use rand_core::OsRng;
 
 use crate::common::MIN_BIT_LENGTH;
 pub use crate::common::{

--- a/src/prime.rs
+++ b/src/prime.rs
@@ -29,10 +29,11 @@ mod tests {
 
     #[test]
     fn tests() {
+        let mut rng = rand::thread_rng();
         for bits in &[128, 256, 512, 1024] {
             let n = new(*bits).unwrap();
-            assert!(check(&n));
-            assert!(strong_check(&n));
+            assert!(check(&n, &mut rng));
+            assert!(strong_check(&n, &mut rng));
         }
     }
 }

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -1,5 +1,5 @@
 use num_bigint::{BigUint, RandBigInt};
-use rand::Rng;
+use rand_core::RngCore;
 
 /// Iterator to generate a given amount of random numbers. For convenience of
 /// use with miller_rabin tests, you can also append a specified number at the
@@ -12,7 +12,7 @@ pub struct Randoms<R> {
     rng: R,
 }
 
-impl<R: Rng> Randoms<R> {
+impl<R: RngCore> Randoms<R> {
     pub fn new(lower_limit: BigUint, upper_limit: BigUint, amount: usize, rng: R) -> Self {
         Self {
             appended: None,
@@ -37,7 +37,7 @@ impl<R: Rng> Randoms<R> {
     }
 }
 
-impl<R: Rng> Iterator for Randoms<R> {
+impl<R: RngCore> Iterator for Randoms<R> {
     type Item = BigUint;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/safe_prime.rs
+++ b/src/safe_prime.rs
@@ -1,6 +1,6 @@
 //! Generates cryptographically secure safe prime numbers.
 
-use rand::rngs::OsRng;
+use rand_core::OsRng;
 
 use crate::common::MIN_BIT_LENGTH;
 pub use crate::common::{

--- a/src/safe_prime.rs
+++ b/src/safe_prime.rs
@@ -29,10 +29,11 @@ mod tests {
 
     #[test]
     fn tests() {
+        let mut rng = rand::thread_rng();
         for bits in &[128, 256, 384] {
             let n = new(*bits).unwrap();
-            assert!(check(&n));
-            assert!(strong_check(&n));
+            assert!(check(&n, &mut rng));
+            assert!(strong_check(&n, &mut rng));
         }
     }
 }


### PR DESCRIPTION
Another patch of bringing this library a bit closer to no_std. Now `rand` crate is used with no_std for library, but with std for tests.

This only touches the functions in "common" module, so does not affect public api.