### PR TITLE
Replace lazy_static with once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ num-bigint = { version = "0.4", features = ["rand"] }
 num-traits = "0.2"
 num-integer = "0.1"
 rand_core = { version = "0.6", features = ["getrandom"] }
-lazy_static = "1.4"
+once_cell = "1.17"
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rand_core = { version = "0.6", features = ["getrandom"] }
 once_cell = "1.17"
 
 [dev-dependencies]
-criterion = { version = "0.4", features = ["html_reports"] }
+criterion = { version = "0.5", features = ["html_reports"] }
 rand = "0.8"
 
 [[bench]]

--- a/src/common.rs
+++ b/src/common.rs
@@ -5,7 +5,7 @@ use num_traits::Signed;
 
 use crate::error::{Error, Result};
 use crate::rand::Randoms;
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use rand_core::RngCore;
 
 pub const MIN_BIT_LENGTH: usize = 128;
@@ -462,15 +462,9 @@ fn is_bit_set(x: &BigUint, i: usize) -> bool {
     res.is_odd()
 }
 
-lazy_static! {
-    static ref PRIMES: Vec<BigUint> = gen_primes();
-}
-lazy_static! {
-    static ref TWO: BigUint = BigUint::from(2_u8);
-}
-lazy_static! {
-    static ref THREE: BigUint = BigUint::from(3_u8);
-}
+static PRIMES: Lazy<Vec<BigUint>> = Lazy::new(|| gen_primes());
+static TWO: Lazy<BigUint> = Lazy::new(|| BigUint::from(2_u8));
+static THREE: Lazy<BigUint> = Lazy::new(|| BigUint::from(3_u8));
 
 fn gen_primes() -> Vec<BigUint> {
     [


### PR DESCRIPTION
This should make it easier for the ecosystem to trim down the dependency tree.

Let me know if you'd like me to bump the patch version too so a new release can be made.