### PR TITLE
Feature-gate dependency on `std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glass_pumpkin"
-version = "1.7.0"
+version = "1.8.0"
 description = "A cryptographically secure prime number generator based on rust's own num-bigint and num-integer"
 keywords = ["prime", "big", "cryptography", "generator", "number"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,7 @@ std = ["once_cell/std"]
 getrandom = ["rand_core/getrandom"]
 # Enables compilation in `no_std` environment
 no_std = ["once_cell/critical-section"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
-core2 = "0.4"
-num-bigint = { version = "0.4", features = ["rand"] }
-num-traits = "0.2"
-num-integer = "0.1"
-rand_core = { version = "0.6", features = ["getrandom"] }
-once_cell = "1.17"
+core2 = { version = "0.4", default-features = false }
+num-bigint = { version = "0.4", default-features = false, features = ["rand"] }
+num-traits = { version = "0.2", default-features = false }
+num-integer = { version = "0.1", default-features = false }
+rand_core = { version = "0.6" }
+once_cell = { version = "1.17", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
@@ -29,3 +29,11 @@ harness = false
 
 [profile.bench]
 opt-level = 3
+
+[features]
+default = ["std", "getrandom"]
+std = ["once_cell/std"]
+# Enables methods that use `OsRng` internally
+getrandom = ["rand_core/getrandom"]
+# Enables compilation in `no_std` environment
+no_std = ["once_cell/critical-section"]

--- a/src/common.rs
+++ b/src/common.rs
@@ -206,7 +206,7 @@ fn _is_prime_basic<R: RngCore + ?Sized>(candidate: &BigUint, q_check: bool, rng:
 /// Minimum checks to be considered okay
 #[inline]
 fn required_checks(bits: usize) -> usize {
-    ((bits as f64).log2() as usize) + 5
+    (bits.checked_ilog2().unwrap_or(1) as usize) + 5
 }
 
 /// Perform Fermat's little theorem on the candidate to determine probable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@
     trivial_casts,
     trivial_numeric_casts
 )]
+#![no_std]
+
 //! A crate for generating large prime numbers, suitable for cryptography.
 //!
 //! Primes are generated similarly to OpenSSL except it applies some recommendations
@@ -16,6 +18,9 @@
 //! 2. Divide the candidate by the first 2048 prime numbers
 //! 3. Test the candidate with Fermat's Theorem.
 //! 4. Runs Baillie-PSW test with `log2(bits) + 5` Miller-Rabin tests
+
+#[cfg(test)]
+extern crate alloc;
 
 mod common;
 pub mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
     trivial_casts,
     trivial_numeric_casts
 )]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![no_std]
 
 //! A crate for generating large prime numbers, suitable for cryptography.

--- a/src/prime.rs
+++ b/src/prime.rs
@@ -1,10 +1,10 @@
 //! Generates cryptographically secure prime numbers.
 
-use rand_core::OsRng;
-
 pub use crate::common::{
     gen_prime as from_rng, is_prime as check_with, is_prime_baillie_psw as strong_check_with,
 };
+
+#[cfg(feature = "getrandom")]
 use crate::error::Result;
 
 /// Constructs a new prime number with a size of `bit_length` bits.
@@ -13,8 +13,9 @@ use crate::error::Result;
 /// `from_rng()` function.
 ///
 /// Note: the `bit_length` MUST be at least 128-bits.
+#[cfg(feature = "getrandom")]
 pub fn new(bit_length: usize) -> Result {
-    from_rng(bit_length, &mut OsRng)
+    from_rng(bit_length, &mut rand_core::OsRng)
 }
 
 /// Test if number is prime by
@@ -23,13 +24,15 @@ pub fn new(bit_length: usize) -> Result {
 /// 2- Perform a Fermat Test
 /// 3- Perform log2(bitlength) + 5 rounds of Miller-Rabin
 ///    depending on the number of bits
+#[cfg(feature = "getrandom")]
 pub fn check(candidate: &num_bigint::BigUint) -> bool {
-    check_with(candidate, &mut OsRng)
+    check_with(candidate, &mut rand_core::OsRng)
 }
 
 /// Checks if number is a prime using the Baillie-PSW test
+#[cfg(feature = "getrandom")]
 pub fn strong_check(candidate: &num_bigint::BigUint) -> bool {
-    strong_check_with(candidate, &mut OsRng)
+    strong_check_with(candidate, &mut rand_core::OsRng)
 }
 
 #[cfg(test)]

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -59,6 +59,8 @@ impl<R: RngCore> Iterator for Randoms<R> {
 
 #[cfg(test)]
 mod test {
+    use alloc::vec::Vec;
+
     use super::Randoms;
     use rand::thread_rng;
 

--- a/src/safe_prime.rs
+++ b/src/safe_prime.rs
@@ -1,11 +1,11 @@
 //! Generates cryptographically secure safe prime numbers.
 
-use rand_core::OsRng;
-
 pub use crate::common::{
     gen_safe_prime as from_rng, is_safe_prime as check_with,
     is_safe_prime_baillie_psw as strong_check_with,
 };
+
+#[cfg(feature = "getrandom")]
 use crate::error::Result;
 
 /// Constructs a new safe prime number with a size of `bit_length` bits.
@@ -14,18 +14,21 @@ use crate::error::Result;
 /// `from_rng()` function.
 ///
 /// Note: the `bit_length` MUST be at least 128-bits.
+#[cfg(feature = "getrandom")]
 pub fn new(bit_length: usize) -> Result {
-    from_rng(bit_length, &mut OsRng)
+    from_rng(bit_length, &mut rand_core::OsRng)
 }
 
 /// Checks if number is a safe prime
+#[cfg(feature = "getrandom")]
 pub fn check(candidate: &num_bigint::BigUint) -> bool {
-    check_with(candidate, &mut OsRng)
+    check_with(candidate, &mut rand_core::OsRng)
 }
 
 /// Checks if number is a safe prime using the Baillie-PSW test
+#[cfg(feature = "getrandom")]
 pub fn strong_check(candidate: &num_bigint::BigUint) -> bool {
-    strong_check_with(candidate, &mut OsRng)
+    strong_check_with(candidate, &mut rand_core::OsRng)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
* Make crate `no_std`-friendly, disable unnecessary features in deps to avoid transitive dependency on `std`
* Add features `std` and `getrandom` that enable dep on appropriate crates
  * `std` feature only enables `std` feature for crate `once_cell`
  * `getrandom` gates usages of `OsRng` (which may not be available in no_std)
  * These features are enabled by default to be backwards-compatible with previous version
* Add feature `no_std` that enables dependencies required for the crate to compile in `no_std` environment
  * It enables `critical-section` feature on `once_cell` crate
* Remove usage of `f64::log2`, which is not available in `no_std`, and replace it with `usize::checked_ilog2` that produces the same result and is more efficient
* Enable `doc_auto_cfg` language feature when built on docs.rs. It automatically adds to feature-gated methods a visual block describing what features are required for this method, like on the screenshot: 
  <img width="300" alt="image" src="https://github.com/user-attachments/assets/ac2f4290-94a8-4a7a-9075-ab16ccc7386b" />

You can use these commands to:
* build in `no_std` target and make sure there's no transitive dependency on `std`:
  ```bash
  rustup target add thumbv7m-none-eabi # any `...-none-...` target will work.
  cargo build --no-default-features -F no_std --target thumbv7m-none-eabi
  ```
* build docs with a visual block for feature-gated methods:
   ```bash
   RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --no-deps
   ```

Closes #27