### PR TITLE
Fix docs.rs build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
     trivial_casts,
     trivial_numeric_casts
 )]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![no_std]
 
 //! A crate for generating large prime numbers, suitable for cryptography.


### PR DESCRIPTION
I noticed that docs build fails on docs.rs after my PR #28 with [this error message](https://docs.rs/crate/glass_pumpkin/1.8.0/builds/2632312):

```text
[INFO] [stderr] error[E0557]: feature has been removed
[INFO] [stderr]   --> src/lib.rs:10:29
[INFO] [stderr]    |
[INFO] [stderr] 10 | #![cfg_attr(docsrs, feature(doc_auto_cfg))]
[INFO] [stderr]    |                             ^^^^^^^^^^^^ feature has been removed
[INFO] [stderr]    |
[INFO] [stderr]    = note: removed in 1.92.0; see <https://github.com/rust-lang/rust/pull/138907> for more information
[INFO] [stderr]    = note: merged into `doc_cfg`
```

Replacing this feature with `doc_cfg` fixes an error. I checked that docs are building on latest nightly.