### PR TITLE
Replace core2 with core in 1.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glass_pumpkin"
-version = "1.9.0"
+version = "1.9.1"
 description = "A cryptographically secure prime number generator based on rust's own num-bigint and num-integer"
 keywords = ["prime", "big", "cryptography", "generator", "number"]
 license = "Apache-2.0"
@@ -12,7 +12,6 @@ readme = "README.md"
 edition = "2024"
 
 [dependencies]
-core2 = { version = "0.4", default-features = false }
 num-bigint = { version = "0.4", default-features = false, features = ["rand"] }
 num-traits = { version = "0.2", default-features = false }
 num-integer = { version = "0.1", default-features = false }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@
 
 use crate::common::MIN_BIT_LENGTH;
 use core::{fmt, result};
-use core2::error;
+use core::error;
 
 /// Default result struct
 pub type Result = result::Result<num_bigint::BigUint, Error>;


### PR DESCRIPTION
I see that you're preparing for a 2.0 release, which is good. We won't be able to update to it for some time, because for us bumping the rand_core version is too difficult. And the 1.\* version still don't build because of the yanked `core2` dependency. So I propose to backport one change back to 1.9: removing core2

This won't merge to main, because the changed is based on an older revision (667a6fa9435b9ca695e72c7cf9a1a45b077583b4, introducing 1.9). I think the best course if you want to accept this change is to create a separate branch for the 1.\* versions for any future backporting, and merge this change there